### PR TITLE
Return source and source list regardless of state

### DIFF
--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -354,7 +354,10 @@ class DenonDevice(MediaPlayerDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
-        attributes = {}
+        attributes = {
+            'source': self._current_source,
+            'source_list': self._source_list
+        }
         if (
             self._sound_mode_raw is not None
             and self._sound_mode_support


### PR DESCRIPTION
## Description:

Receivers in general can passthrough the video/audio to the TV when the receiver state is off. Therefore, it is still useful to return the source/sourcelist even when the receiver is off. 

I am updating just the denonavr code but all receiver code should be updated accordingly.


